### PR TITLE
Copy License and Change Log on Build

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -176,6 +176,23 @@ export class Build {
             options,
           }));
       }
+      
+      if (await fs.exists(path.join(cwd, 'CHANGELOG'))) {
+        fs.copyFile(path.join(cwd, 'CHANGELOG'), path.join(out, 'CHANGELOG'));
+        reporter.log(`      📝  ` + chalk.green(outPretty + 'CHANGELOG'));
+      } else if (await fs.exists(path.join(cwd, 'CHANGELOG.md'))) {
+        fs.copyFile(path.join(cwd, 'CHANGELOG.md'), path.join(out, 'CHANGELOG.md'));
+        reporter.log(`      📝  ` + chalk.green(outPretty + 'CHANGELOG.md'));
+      }
+      
+      if (await fs.exists(path.join(cwd, 'LICENSE'))) {
+        fs.copyFile(path.join(cwd, 'LICENSE'), path.join(out, 'LICENSE'));
+        reporter.log(`      📝  ` + chalk.green(outPretty + 'LICENSE'));
+      } else if (await fs.exists(path.join(cwd, 'LICENSE.md'))) {
+        fs.copyFile(path.join(cwd, 'LICENSE.md'), path.join(out, 'LICENSE.md'));
+        reporter.log(`      📝  ` + chalk.green(outPretty + 'LICENSE.md'));
+      }
+      
       if (await fs.exists(path.join(cwd, 'README'))) {
         fs.copyFile(path.join(cwd, 'README'), path.join(out, 'README'));
         reporter.log(`      📝  ` + chalk.green(outPretty + 'README'));


### PR DESCRIPTION
Used the existing code for finding/copying Readme files to also look for and copy License and Changelog files. NPM never ignores these files, and at the very least a package's License file should be published if it exists for legal reasons.