### PR TITLE
Added gitpod config and contribution section

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+- before: npm install -g @pika/pack
+  init: npm install
+  command: pack build

--- a/README.md
+++ b/README.md
@@ -119,3 +119,16 @@ This is all possible because **@pika/pack** builds your entire package: code, as
 We've brought our favorite parts of [np](https://github.com/sindresorhus/np) (a self-described "better npm publish") into **@pika/pack**. With the `publish` command there's no need to worry about how to publish your package once you've built it.
 
 Run `pack publish` in your project and **@pika/pack** will walk you through version bumping, tagging your release, generating a fresh build, and finally publishing your package.
+
+## Contributing
+
+Clone the repo, then:
+```sh
+npm install -g @pika/pack
+npm install
+pack build
+```
+
+Or use Gitpod, a free online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/pikapkg/pack)


### PR DESCRIPTION
This PR adds a contribution section to the readme together with a config for Gitpod, a free online dev environment for GitHub that allows anyone to start coding on 'pack' without going local.
The IDE in Gitpod is based on VS Code and has the same level of TypeScript support, so this is not only for small on-the-go contributions but works all the way. It even has debugging support.

I configured it so it 
 - installs pack globally, 
 - runs `npm install`
 - runs `pack build`

You can even review PRs in it by prefixing a github URL with `https://gitpod.io#`. 
E.g. this one:

https://gitpod.io#https://github.com/pikapkg/pack/pull/9

<img width="1363" alt="screenshot 2019-02-08 at 08 28 33" src="https://user-images.githubusercontent.com/372735/52464668-19c83100-2b7c-11e9-97e0-b472bef12bc8.png">

