### PR TITLE
Added `--skip-version-check` flag to `pika publish` command

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -20,6 +20,7 @@ type Flags = {
   yolo: boolean,
   publish: boolean,
   tag: boolean,
+  skipVersionCheck: boolean,
   yarn: boolean,
   contents: boolean,
   otp?: string,
@@ -34,6 +35,7 @@ export function setFlags(commander: Command) {
   commander.option('--yolo', 'Skips cleanup and testing');
   commander.option('--no-publish', 'Skips publishing');
   commander.option('--tag', ' Publish under a given dist-tag');
+  commander.option('--skip-version-check', 'Skip the version check')
   commander.option('--no-yarn', " Don't use Yarn");
   commander.option('--contents', 'Subdirectory to publish', 'pkg/');
   commander.option('--otp <code>', 'Publish with an OTP code');

--- a/src/util/publish/prerequisite.ts
+++ b/src/util/publish/prerequisite.ts
@@ -67,7 +67,7 @@ export default async function prerequisites(input, pkg, options) {
   }
 
   newVersion = version.getNewVersion(pkg.version, input);
-  if (!version.isVersionGreater(pkg.version, newVersion)) {
+  if (!options.skipVersionCheck && !version.isVersionGreater(pkg.version, newVersion)) {
     throw new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``);
   }
 


### PR DESCRIPTION
Hello all and thanks for this great tool :)

I published yesterday [my first package built with `pack`](https://www.npmjs.com/package/s3-list-bucket-stream) and I have to say it was a very nice experience. 🤩

This PR adds the support for `--skip-version-check` flag during publish.

When the flag is set, the check to see if the current package version (in `package.json`) is lower than the version that we are going to publish.

The reason why I think this is useful is that some build pipelines (like the one for the project I mentioned above) will assume that the version has been already bumped in the `package.json` (before the merge) to be more in control on how to bump the package on every change.

When a pipeline is adopting this approach, `pack publish` will refuse to publish the built artifact because the current version is the same as the target version.

I would ideally publish with a command like the following:

```bash
pack publish --no-yarn --verbose $npm_package_version
```

(Note that `$npm_package_version` will be replaced at runtime with the current version as specified in the `package.json` `version` field).

But this approach will fail the version check in `pack`.

I ended up doing a _dirty hack_ (for lack of better words) in my repo. I am always keeping the `version` to `0.0.1` in my main `package.json` and having a file called `VERSION` with the actual version of the package.
Then I replaced the reference `$npm_package_version` with `$(head -n 1 VERSION)`.

This works, but it's very obscure and definitely not ideal, hence I would love to have an option directly in `pack publish` to be able to better support use cases such as mine.

**Word of warning**: I wasn't very sure how to test this, so this comes mostly untested. Happy to write tests or do some manual testing if you give me some indication on what you expect on this regard.
