### PR TITLE
Skip prereq check if windows

### DIFF
--- a/src/util/publish/prerequisite.ts
+++ b/src/util/publish/prerequisite.ts
@@ -2,9 +2,11 @@ import execa from 'execa';
 import pTimeout from 'p-timeout';
 import * as version from './version.js';
 import {getTagVersionPrefix} from './util.js';
+import {type} from 'os';
 
 export default async function prerequisites(pkg, options) {
   const isExternalRegistry = typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
+  const isWindows=type()==='Windows_NT'
   let newVersion = null;
 
   // title: 'Ping npm registry',
@@ -23,7 +25,7 @@ export default async function prerequisites(pkg, options) {
   }
 
   // title: 'Verify user is authenticated',
-  if (!(process.env.NODE_ENV === 'test' || pkg.private || isExternalRegistry)) {
+  if (!(process.env.NODE_ENV === 'test' || pkg.private || isExternalRegistry) && !isWindows ) {
     let username;
     try {
       username = await execa.stdout('npm', ['whoami']);


### PR DESCRIPTION
Quick fix for #37 & #2 

After playing around it, i determined its a straight up issue with child.process.exec and npm on windows default shell. Therefore this quick fix just completely skips prereq checks if windows, and will rely on [publish.ts](https://github.com/pikapkg/pack/blob/253a7639b24cf3c0aaece0a44c7180d680dcb2b5/src/util/publish/publish.ts#L50) to report access errors if publishing fails.

I successfully published [pikaaccesstest](https://www.npmjs.com/package/@roseys/pikaaccesstest)