### PR TITLE
build: improve error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
       "dev": true
     },
     "@pika/cli": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@pika/cli/-/cli-0.1.4.tgz",
-      "integrity": "sha512-4YWPrSjQSEDdAq8Y8IdNL9n9a6ke2TRoUgLnkrXHCCMMtacnbIN57CvZgaVwN4PXTL9cZgMz7URAYQLYr6A/1g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@pika/cli/-/cli-0.2.0.tgz",
+      "integrity": "sha512-DUWKfjpwXPGQlnYok2lqOLYuirTteEkXnLOWVYXAuS76BJv1dgCZkWG/tnLMb1DB7Xd4vtyp96/ajmfYceD2gQ==",
       "requires": {
         "chalk": "^2.4.2",
         "detect-indent": "^6.0.0",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -141,6 +141,11 @@ export class Build {
             console.error('      ❗️  ', chalk.red(err.message), chalk.dim('--force, continuing...'));
           } else {
             console.error('      ❗️  ', chalk.red(err.message));
+            if (err.loc && err.frame) {
+              console.error('      ❗️  ', chalk.bold('ERROR OUTPUT:'), '\n');
+              err.loc.file && console.error(err.loc.file);
+              console.error(err.frame, '\n');
+            }
             if (err.all) {
               console.error('      ❗️  ', chalk.bold('ERROR OUTPUT:'));
               console.error(err.all);


### PR DESCRIPTION
Currently when a builder fails (ex: @pika/plugin-build-web) the error message is not helpful when we need to debug what is causing the failure:

Before:

```ts
lerna ERR! npm run build stderr:
      ❗️   Unexpected token
Error: Unexpected token
    at error (path/@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at Module.error (path/@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:9824:16)
    at tryParse (path/@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:9717:23)
    at Module.setSource (path/@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:10080:33)
    at path/@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:12366:20
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
Error: Command failed with exit code 1 (EPERM): npx pika-pack
    at makeError (path/execa/lib/error.js:59:11)
    at handlePromise (path/execa/index.js:150:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async runExternalCommand (path/@pika/cli/dist-node/index.js:83:5)
    at async cli (path/@pika/cli/dist-node/index.js:141:43)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! package@1.3.0 build: `pika build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the package@1.3.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
After:

```ts
lerna ERR! npm run build stderr:
      ❗️   Unexpected token
      ❗️   ERROR OUTPUT: 

path/pkg/dist-src/EntityFilter.js 
26: 
27:   const handleOutsideClick = e => {
28:     if (!wrapperRef.current?.contains(e.target)) {
                                ^
29:       setFocus(false);
30:       showSuggestions(false); 

Error: Unexpected token
    at error (path@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at Module.error (path@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:9824:16)
    at tryParse (path@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:9717:23)
    at Module.setSource (path@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:10080:33)
    at path@pika/plugin-build-web/node_modules/rollup/dist/shared/node-entry.js:12366:20
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
    at async Promise.all (index 0)
Error: Command failed with exit code 1 (EPERM): npx pika-pack
    at makeError (pathexeca/lib/error.js:59:11)
    at handlePromise (pathexeca/index.js:150:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async runExternalCommand (path@pika/cli/dist-node/index.js:83:5)
    at async cli (path@pika/cli/dist-node/index.js:141:43)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! package@1.3.0 build: `pika build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the package@1.3.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

This makes it easier to spot what's causing the issue, which in this case was a missing babel plugin.


/cc @FredKSchott 