### PR TITLE
Throw error when top-level package.json is missing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,9 +47,9 @@ export default class Config {
       this._manifest = {...info.object};
       this.manifest = await normalizeManifest(info.object, this.cwd, this, true);
       return this.manifest;
-    } else {
-      return null;
     }
+
+    throw new Error('No top-level package.json manifest found.')
   }
 
   readJson(loc: string, factory: (filename: string) => Promise<any> = fs.readJson): Promise<any> {


### PR DESCRIPTION
This add an error case when loading the package manifest and the file doesn't exist. Now instead of failing on an undefined TypeError when `this.manifest` is undefined or null later in the command, it fails with an uncaught error with a message of "No top-level package.json manifest found.".

Right now this shows up as an uncaught error with a stacktrace and everything, but if it's better to print this with `console.error` and then end the process I can make those changes.

Fixes #76 